### PR TITLE
Add closing tag to iframe element

### DIFF
--- a/app/views/admin/trestle/sidekiq/sidekiq/index.html.erb
+++ b/app/views/admin/trestle/sidekiq/sidekiq/index.html.erb
@@ -1,3 +1,3 @@
 <% content_for(:title, "Sidekiq") %>
 
-<iframe src="<%= sidekiq_web_path %>" class="sidekiq-iframe" />
+<iframe src="<%= sidekiq_web_path %>" class="sidekiq-iframe"></iframe>


### PR DESCRIPTION
`<iframe>` is not a self-closing tag so must have a closing `</iframe>`.